### PR TITLE
feat: mid-text /skill autocomplete with inline ghost completion

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -5,6 +5,7 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { extractGlobs, hasGlobs, matchesGlobs } from "./globs";
+import { setupSkillAutocomplete } from "./skill-autocomplete";
 
 type SkillRecord = {
 	name: string;
@@ -39,6 +40,35 @@ function normalizeSkill(raw: unknown): SkillRecord | undefined {
 	const baseDir = typeof obj.baseDir === "string" ? obj.baseDir : filePath ? dirname(filePath) : undefined;
 	if (!name || !filePath || !baseDir) return undefined;
 	return { name, filePath, baseDir };
+}
+
+// ponytail: hand-rolls pi's package cache layout (github.com/<owner>/<repo> ->
+// ~/.pi/agent/git/...). Only github.com git specs resolve; npm and non-github
+// hosts get no pre-prompt discovery (before_agent_start still merges pi's set).
+// Upgrade to an extension API exposing active skill roots when pi provides one.
+function packageRootFromSource(source: string): string | undefined {
+	if (source.startsWith("/") || source.startsWith("~/")) return homePath(source);
+	if (!source.startsWith("git:")) return undefined;
+	let spec = source.slice("git:".length).replace(/\.git$/, "");
+	spec = spec.replace(/^https?:\/\/github\.com\//, "github.com/");
+	if (!spec.startsWith("github.com/")) return undefined;
+	return homePath(`~/.pi/agent/git/${spec}`);
+}
+
+function activePackageRootsFromSettings(): string[] {
+	try {
+		const settings = JSON.parse(readFileSync(homePath("~/.pi/agent/settings.json"), "utf-8")) as { packages?: unknown[] };
+		const roots: string[] = [];
+		for (const entry of settings.packages ?? []) {
+			const source = typeof entry === "string" ? entry : entry && typeof entry === "object" ? (entry as { source?: unknown }).source : undefined;
+			if (typeof source !== "string") continue;
+			const root = packageRootFromSource(source);
+			if (root) roots.push(root);
+		}
+		return roots;
+	} catch {
+		return [];
+	}
 }
 
 function scanSkillRoots(roots: string[]): SkillRecord[] {
@@ -130,6 +160,8 @@ function extractFrontmatterFields(text: string): { model?: string; thinking?: st
 
 export default function skillRelativePaths(pi: ExtensionAPI) {
 	let skills = new Map<string, SkillRecord>();
+	let skillList: SkillRecord[] = [];
+	let cachedPackageRoots: string[] | undefined;
 	let activeSkill: SkillRecord | undefined;
 	// Tracks skills auto-injected via globs in the current turn (deduplication).
 	let injectedThisTurn = new Set<string>();
@@ -252,6 +284,14 @@ export default function skillRelativePaths(pi: ExtensionAPI) {
 			homePath("~/.agents/skills"),
 			resolve(cwd, ".pi/skills"),
 		];
+		// Active package roots are session-static; parse settings once.
+		if (!cachedPackageRoots) cachedPackageRoots = activePackageRootsFromSettings();
+		// Package skills live under <pkg>/skills/** (or <pkg>/SKILL.md); don't walk the
+		// whole repo tree (src/dist/tests/...) on every turn.
+		for (const root of cachedPackageRoots) {
+			roots.push(join(root, "skills"));
+			if (existsSync(join(root, "SKILL.md"))) roots.push(root);
+		}
 		for (const skill of scanSkillRoots(roots)) {
 			const existing = next.get(skill.name);
 			if (existing) {
@@ -264,6 +304,7 @@ export default function skillRelativePaths(pi: ExtensionAPI) {
 			}
 		}
 		skills = next;
+		skillList = Array.from(next.values());
 	}
 
 	function isTrustedForDynamicShell(skill: SkillRecord): boolean {
@@ -443,6 +484,7 @@ export default function skillRelativePaths(pi: ExtensionAPI) {
 
 	pi.on("session_start", async (_event, ctx) => {
 		refreshSkills(ctx.cwd);
+		if (ctx.hasUI) setupSkillAutocomplete(ctx, () => skillList);
 	});
 
 	pi.on("turn_start", async () => {

--- a/index.ts
+++ b/index.ts
@@ -42,10 +42,13 @@ function normalizeSkill(raw: unknown): SkillRecord | undefined {
 	return { name, filePath, baseDir };
 }
 
-// ponytail: hand-rolls pi's package cache layout (github.com/<owner>/<repo> ->
-// ~/.pi/agent/git/...). Only github.com git specs resolve; npm and non-github
-// hosts get no pre-prompt discovery (before_agent_start still merges pi's set).
-// Upgrade to an extension API exposing active skill roots when pi provides one.
+// ponytail: hand-rolls pi's package cache layout. Only `git:github.com/...`
+// specs resolve to ~/.pi/agent/git/...; it does NOT cover npm specs, SSH/https
+// git URLs, branch refs (git:...@ref), project-local .pi/settings.json, or
+// per-package `skills: []` filters. before_agent_start still merges pi's
+// authoritative loaded set at runtime, so affected skills merely lack
+// pre-prompt discovery (never resolution). Upgrade to an extension API
+// exposing active skill roots when pi provides one.
 function packageRootFromSource(source: string): string | undefined {
 	if (source.startsWith("/") || source.startsWith("~/")) return homePath(source);
 	if (!source.startsWith("git:")) return undefined;

--- a/index.ts
+++ b/index.ts
@@ -4,6 +4,7 @@ import { homedir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { stripFrontmatter } from "@earendil-works/pi-coding-agent";
 import { extractGlobs, hasGlobs, matchesGlobs } from "./globs";
 import { setupSkillAutocomplete } from "./skill-autocomplete";
 
@@ -72,6 +73,88 @@ function activePackageRootsFromSettings(): string[] {
 	} catch {
 		return [];
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Multi-skill invocation
+// ---------------------------------------------------------------------------
+// pi core only expands a *single* leading `/skill:<name>` per message
+// (`AgentSession._expandSkillCommand`); any additional `/skill:<name>` tokens
+// are passed through as literal text. This helper lets a message reference
+// multiple skills: the leading token is left untouched for pi core, and every
+// *additional* resolvable token is replaced in place with the same `<skill>`
+// XML block core itself produces. Replacement is in place (not appended) so the
+// user's text ordering is preserved, and the leading `/skill:` stays at index 0
+// so core keeps owning the leading skill.
+
+export type InlineSkillRef = {
+	name: string;
+	filePath: string;
+	baseDir: string;
+};
+
+const INLINE_SKILL_TOKEN = /\/skill:([A-Za-z0-9._-]+)/g;
+
+/**
+ * Replace non-leading `/skill:<name>` tokens in place with `<skill>` XML blocks.
+ *
+ * Returns the rewritten text plus the names of injected skills, or `undefined`
+ * when there is nothing to inject (so callers can leave the message untouched).
+ * The leading token (at index 0) is always skipped — pi core handles it.
+ * Unknown or unreadable skills are left verbatim so core/pi can report them.
+ *
+ * `decorate`, if provided, wraps the skill body (e.g. with `<skill_context>`);
+ * it receives the body and must return the inner content of the `<skill>` block.
+ */
+export function expandInlineSkills(
+	text: string,
+	resolve: (name: string) => InlineSkillRef | undefined,
+	readBody: (skill: InlineSkillRef) => string,
+	decorate?: (body: string, skill: InlineSkillRef) => string,
+): { text: string; injected: string[] } | undefined {
+	if (!text.includes("/skill:")) return undefined;
+
+	const matches = [...text.matchAll(INLINE_SKILL_TOKEN)].filter((match) => {
+		const start = match.index ?? 0;
+		return start === 0 || /\s/.test(text[start - 1] ?? "");
+	});
+	if (matches.length === 0) return undefined;
+
+	type Replacement = { start: number; end: number; block: string };
+	const replacements: Replacement[] = [];
+	const injected: string[] = [];
+
+	for (const match of matches) {
+		const start = match.index ?? 0;
+		if (start === 0) continue; // leading skill -> pi core expands it
+		const skill = resolve(match[1] ?? "");
+		if (!skill) continue; // unknown skill: leave token verbatim
+
+		let body: string;
+		try {
+			body = readBody(skill);
+		} catch {
+			continue; // unreadable SKILL.md: leave token verbatim
+		}
+
+		const inner = decorate ? decorate(body, skill) : body;
+		const block = `<skill name="${skill.name}" location="${skill.filePath}">\nReferences are relative to ${skill.baseDir}.\n\n${inner}\n</skill>`;
+		replacements.push({ start, end: start + match[0].length, block });
+		injected.push(skill.name);
+	}
+
+	if (replacements.length === 0) return undefined;
+
+	replacements.sort((a, b) => a.start - b.start);
+	let out = "";
+	let cursor = 0;
+	for (const { start, end, block } of replacements) {
+		out += text.slice(cursor, start) + block;
+		cursor = end;
+	}
+	out += text.slice(cursor);
+
+	return { text: out, injected };
 }
 
 function scanSkillRoots(roots: string[]): SkillRecord[] {
@@ -488,6 +571,24 @@ export default function skillRelativePaths(pi: ExtensionAPI) {
 	pi.on("session_start", async (_event, ctx) => {
 		refreshSkills(ctx.cwd);
 		if (ctx.hasUI) setupSkillAutocomplete(ctx, () => skillList);
+	});
+
+	// Expand additional `/skill:<name>` references beyond the leading one pi core
+	// already handles. Runs before core's skill expansion; transform is a no-op
+	// (returns continue) when there are no extra resolvable tokens.
+	pi.on("input", async (event, ctx) => {
+		if (event.source === "extension") return; // don't rewrite extension-injected text
+		const result = expandInlineSkills(
+			event.text,
+			(name) => skills.get(name),
+			(skill) => stripFrontmatter(readFileSync(skill.filePath, "utf-8")).trim(),
+			// Wrap the body with the same <skill_context> block the extension injects
+			// when a SKILL.md is read, so relative-path resolution applies to these
+			// multi-skill invocations too (core's own leading-skill block lacks it).
+			(body, skill) => insertSkillContext(body, skill, ctx.cwd),
+		);
+		if (!result) return;
+		return { action: "transform" as const, text: result.text };
 	});
 
 	pi.on("turn_start", async () => {

--- a/package.json
+++ b/package.json
@@ -8,13 +8,20 @@
   },
   "scripts": {
     "test": "bun test",
-    "build": "bun build index.ts --outdir=."
+    "build": "bun build index.ts --target=node --external @earendil-works/pi-coding-agent --external @earendil-works/pi-tui --outdir=."
   },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/edxeth/pi-better-skills.git"
   },
-  "keywords": [],
+  "keywords": [
+    "pi-package"
+  ],
+  "pi": {
+    "extensions": [
+      "./index.ts"
+    ]
+  },
   "author": "",
   "license": "ISC",
   "type": "commonjs",
@@ -24,5 +31,9 @@
   "homepage": "https://github.com/edxeth/pi-better-skills#readme",
   "dependencies": {
     "picomatch": "^4.0.4"
+  },
+  "peerDependencies": {
+    "@earendil-works/pi-coding-agent": "*",
+    "@earendil-works/pi-tui": "*"
   }
 }

--- a/skill-autocomplete.ts
+++ b/skill-autocomplete.ts
@@ -33,12 +33,15 @@ type SkillAutocompleteHit = {
 	ci: number;
 };
 
-function slashTokenAtCursor(line: string, col: number): SlashToken | undefined {
+function slashTokenAtCursor(line: string, col: number, allowLineStart = false): SlashToken | undefined {
 	const slashIndex = line.lastIndexOf("/", col - 1);
 	if (slashIndex === -1) return undefined;
 	const beforeSlash = line.slice(0, slashIndex);
 	if (beforeSlash.length > 0 && !/\s$/.test(beforeSlash)) return undefined;
-	if (beforeSlash.trim() === "") return undefined;
+	// A bare `/skill:` at the start of a line: on line 0 pi's built-in slash menu
+	// owns it, so bail (defer). On later lines there is no built-in menu
+	// (pi-tui gates it to cursorLine === 0), so allow completion there.
+	if (beforeSlash.trim() === "" && !(allowLineStart && slashIndex === 0)) return undefined;
 	const token = line.slice(slashIndex).match(/^\/\S*/)?.[0];
 	if (!token) return undefined;
 	const end = slashIndex + token.length;
@@ -60,7 +63,7 @@ function computeSkillAutocompleteHit(
 ): SkillAutocompleteHit | null {
 	const line = lines[ci] ?? "";
 	if (col !== line.length) return null;
-	const hit = slashTokenAtCursor(line, col);
+	const hit = slashTokenAtCursor(line, col, ci !== 0);
 	if (!hit || hit.query.length === 0 || hit.end !== line.length) return null;
 	const query = hit.query.toLowerCase();
 	let best: SkillAutocompleteSkill | undefined;
@@ -108,6 +111,13 @@ class SkillGhostEditor extends CustomEditor {
 		private readonly getSkills: () => SkillAutocompleteSkill[],
 	) {
 		super(tui, theme, keybindings);
+
+		// ponytail: pi-tui's Editor gates slash autocomplete to `cursorLine === 0`
+		// (private `isSlashMenuAllowed`). That leaves later lines with no popup at all.
+		// Override it so the skill popup (and the built-in slash menu) can trigger on any
+		// line. The method is private in the type, so poke it through the same isolated
+		// cast used for cursor state below. Upgrade to a public hook when pi-tui adds one.
+		(this as unknown as { isSlashMenuAllowed: () => boolean }).isSlashMenuAllowed = () => true;
 	}
 
 	private currentHit(): SkillAutocompleteHit | null {
@@ -161,6 +171,17 @@ class SkillGhostEditor extends CustomEditor {
 			}
 		}
 		super.handleInput(data);
+
+		// pi-tui only auto-triggers slash completion when `/` starts the current
+		// line, so a `/skill:` that follows other text on a line never opens the
+		// popup. If there's a skill token at the cursor and no popup is up yet, ask
+		// pi-tui to trigger; our provider will supply (or decline) skill items.
+		if (!this.isShowingAutocomplete()) {
+			const { line, col } = this.getCursor();
+			if (slashTokenAtCursor(this.getLines()[line] ?? "", col, line !== 0)) {
+				(this as unknown as { tryTriggerAutocomplete: () => void }).tryTriggerAutocomplete();
+			}
+		}
 	}
 
 	private acceptHit(hit: SkillAutocompleteHit): void {
@@ -177,7 +198,7 @@ export function setupSkillAutocomplete(ctx: ExtensionContext, getSkills: () => S
 	ctx.ui.addAutocompleteProvider((current): AutocompleteProvider => ({
 		async getSuggestions(lines, cursorLine, cursorCol, options): Promise<AutocompleteSuggestions | null> {
 			const currentLine = lines[cursorLine] ?? "";
-			const hit = slashTokenAtCursor(currentLine, cursorCol);
+			const hit = slashTokenAtCursor(currentLine, cursorCol, cursorLine !== 0);
 			if (!hit) return current.getSuggestions(lines, cursorLine, cursorCol, options);
 			const items = fuzzyFilter(getSkills(), hit.query, (skill) => skill.name).map(skillAutocompleteItem);
 			if (items.length === 0) return current.getSuggestions(lines, cursorLine, cursorCol, options);
@@ -188,7 +209,7 @@ export function setupSkillAutocomplete(ctx: ExtensionContext, getSkills: () => S
 			// (built-in slash/file/path completions) to the wrapped provider.
 			if (!isSkillItem(item)) return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
 			const currentLine = lines[cursorLine] ?? "";
-			const token = slashTokenAtCursor(currentLine, cursorCol);
+			const token = slashTokenAtCursor(currentLine, cursorCol, cursorLine !== 0);
 			const start = token?.start ?? cursorCol - prefix.length;
 			const end = token?.end ?? cursorCol;
 			const insertion = `/${item.value} `;

--- a/skill-autocomplete.ts
+++ b/skill-autocomplete.ts
@@ -9,7 +9,6 @@ import {
 	type TUI,
 	CURSOR_MARKER,
 	fuzzyFilter,
-	getKeybindings,
 } from "@earendil-works/pi-tui";
 
 export type SkillAutocompleteSkill = {
@@ -88,6 +87,10 @@ function skillAutocompleteItem(skill: SkillAutocompleteSkill): AutocompleteItem 
 	};
 }
 
+function isSkillItem(item: AutocompleteItem): boolean {
+	return typeof item.value === "string" && item.value.startsWith("skill:");
+}
+
 function restorePrivateEditorCursor(editor: CustomEditor, cursorLine: number, cursorCol: number): void {
 	// ponytail: pi's Editor has no public setCursor(line, col) yet; poke the
 	// private state field. Upgrade to the public setter when pi-tui adds one.
@@ -142,10 +145,13 @@ class SkillGhostEditor extends CustomEditor {
 		return result;
 	}
 
+	private get kb(): KeybindingsManager {
+		return (this as unknown as { keybindings: KeybindingsManager }).keybindings;
+	}
+
 	handleInput(data: string): void {
-		const kb = getKeybindings();
 		if (
-			(kb.matches(data, "tui.input.tab") || kb.matches(data, "tui.editor.cursorRight")) &&
+			(this.kb.matches(data, "tui.input.tab") || this.kb.matches(data, "tui.editor.cursorRight")) &&
 			!this.isShowingAutocomplete()
 		) {
 			const hit = this.currentHit();
@@ -178,6 +184,9 @@ export function setupSkillAutocomplete(ctx: ExtensionContext, getSkills: () => S
 			return { items, prefix: hit.prefix };
 		},
 		applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+			// Only custom-insert our own skill items; delegate everything else
+			// (built-in slash/file/path completions) to the wrapped provider.
+			if (!isSkillItem(item)) return current.applyCompletion(lines, cursorLine, cursorCol, item, prefix);
 			const currentLine = lines[cursorLine] ?? "";
 			const token = slashTokenAtCursor(currentLine, cursorCol);
 			const start = token?.start ?? cursorCol - prefix.length;
@@ -192,6 +201,11 @@ export function setupSkillAutocomplete(ctx: ExtensionContext, getSkills: () => S
 		},
 	}));
 
+	if (ctx.ui.getEditorComponent?.()) {
+		// Another extension already replaced the editor (vim/modal/accessibility).
+		// Don't clobber it; the popup provider above still covers mid-text completion.
+		return;
+	}
 	ctx.ui.setEditorComponent(
 		(tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager): EditorComponent =>
 			new SkillGhostEditor(tui, theme, keybindings, getSkills),

--- a/skill-autocomplete.ts
+++ b/skill-autocomplete.ts
@@ -1,0 +1,199 @@
+import type { ExtensionContext, KeybindingsManager } from "@earendil-works/pi-coding-agent";
+import { CustomEditor } from "@earendil-works/pi-coding-agent";
+import {
+	type AutocompleteItem,
+	type AutocompleteProvider,
+	type AutocompleteSuggestions,
+	type EditorComponent,
+	type EditorTheme,
+	type TUI,
+	CURSOR_MARKER,
+	fuzzyFilter,
+	getKeybindings,
+} from "@earendil-works/pi-tui";
+
+export type SkillAutocompleteSkill = {
+	name: string;
+};
+
+const GHOST_STYLE = "\x1b[2;38;5;244m";
+const RESET = "\x1b[0m";
+const CURSOR_BLOCK = "\x1b[7m \x1b[0m";
+
+type SlashToken = {
+	prefix: string;
+	query: string;
+	start: number;
+	end: number;
+};
+
+type SkillAutocompleteHit = {
+	ghostText: string;
+	slashIndex: number;
+	replacement: string;
+	ci: number;
+};
+
+function slashTokenAtCursor(line: string, col: number): SlashToken | undefined {
+	const slashIndex = line.lastIndexOf("/", col - 1);
+	if (slashIndex === -1) return undefined;
+	const beforeSlash = line.slice(0, slashIndex);
+	if (beforeSlash.length > 0 && !/\s$/.test(beforeSlash)) return undefined;
+	if (beforeSlash.trim() === "") return undefined;
+	const token = line.slice(slashIndex).match(/^\/\S*/)?.[0];
+	if (!token) return undefined;
+	const end = slashIndex + token.length;
+	if (col > end) return undefined;
+	const rawQuery = line.slice(slashIndex + 1, col);
+	return {
+		prefix: line.slice(slashIndex, col),
+		query: rawQuery.startsWith("skill:") ? rawQuery.slice("skill:".length) : rawQuery,
+		start: slashIndex,
+		end,
+	};
+}
+
+function computeSkillAutocompleteHit(
+	lines: string[],
+	ci: number,
+	col: number,
+	getSkills: () => SkillAutocompleteSkill[],
+): SkillAutocompleteHit | null {
+	const line = lines[ci] ?? "";
+	if (col !== line.length) return null;
+	const hit = slashTokenAtCursor(line, col);
+	if (!hit || hit.query.length === 0 || hit.end !== line.length) return null;
+	const query = hit.query.toLowerCase();
+	let best: SkillAutocompleteSkill | undefined;
+	for (const skill of getSkills()) {
+		const name = skill.name.toLowerCase();
+		if (!name.startsWith(query)) continue;
+		if (name === query) return null; // already complete
+		if (best) return null; // >1 prefix match -> ambiguous -> popup
+		best = skill;
+	}
+	if (!best) return null;
+	return {
+		ghostText: best.name.slice(hit.query.length),
+		slashIndex: hit.start,
+		replacement: `/skill:${best.name} `,
+		ci,
+	};
+}
+
+function skillAutocompleteItem(skill: SkillAutocompleteSkill): AutocompleteItem {
+	return {
+		value: `skill:${skill.name}`,
+		label: `skill:${skill.name}`,
+	};
+}
+
+function restorePrivateEditorCursor(editor: CustomEditor, cursorLine: number, cursorCol: number): void {
+	// ponytail: pi's Editor has no public setCursor(line, col) yet; poke the
+	// private state field. Upgrade to the public setter when pi-tui adds one.
+	const state = (editor as unknown as { state: { cursorLine: number; cursorCol: number } }).state;
+	state.cursorLine = cursorLine;
+	state.cursorCol = cursorCol;
+	editor.invalidate();
+}
+
+class SkillGhostEditor extends CustomEditor {
+	constructor(
+		tui: TUI,
+		theme: EditorTheme,
+		keybindings: KeybindingsManager,
+		private readonly getSkills: () => SkillAutocompleteSkill[],
+	) {
+		super(tui, theme, keybindings);
+	}
+
+	private currentHit(): SkillAutocompleteHit | null {
+		if (!this.focused || this.isShowingAutocomplete()) return null;
+		const { line, col } = this.getCursor();
+		return computeSkillAutocompleteHit(this.getLines(), line, col, this.getSkills);
+	}
+
+	render(width: number): string[] {
+		const result = super.render(width);
+		const hit = this.currentHit();
+		if (!hit || hit.ghostText.length === 0) return result;
+
+		// ponytail: splices ghost text into pi's end-of-line cursor block
+		// (CURSOR_MARKER + highlighted space). Coupled to pi-tui's render format;
+		// any mismatch fails safe (no ghost, editor stays correct).
+		const cursorLineIdx = result.findIndex((line) => line.includes(CURSOR_MARKER));
+		if (cursorLineIdx === -1) return result;
+		const line = result[cursorLineIdx];
+		const blockIdx = line.indexOf(CURSOR_BLOCK, line.indexOf(CURSOR_MARKER) + CURSOR_MARKER.length);
+		if (blockIdx === -1) return result;
+		const afterBlock = blockIdx + CURSOR_BLOCK.length;
+		let trailing = 0;
+		for (let i = line.length - 1; i >= afterBlock && line[i] === " "; i--) trailing++;
+		// ghostText is an ASCII skill slug: 1 char = 1 column, no width utils needed.
+		const shown = hit.ghostText.slice(0, 1 + trailing);
+		if (!shown) return result;
+		const first = shown[0];
+		const rest = shown.slice(1);
+		result[cursorLineIdx] =
+			line.slice(0, blockIdx) +
+			`\x1b[7m${first}\x1b[0m` +
+			(rest ? `${GHOST_STYLE}${rest}${RESET}` : "") +
+			" ".repeat(trailing - rest.length);
+		return result;
+	}
+
+	handleInput(data: string): void {
+		const kb = getKeybindings();
+		if (
+			(kb.matches(data, "tui.input.tab") || kb.matches(data, "tui.editor.cursorRight")) &&
+			!this.isShowingAutocomplete()
+		) {
+			const hit = this.currentHit();
+			if (hit) {
+				this.acceptHit(hit);
+				return;
+			}
+		}
+		super.handleInput(data);
+	}
+
+	private acceptHit(hit: SkillAutocompleteHit): void {
+		const lines = this.getLines();
+		const line = lines[hit.ci] ?? "";
+		const newLines = [...lines];
+		newLines[hit.ci] = line.slice(0, hit.slashIndex) + hit.replacement;
+		this.setText(newLines.join("\n"));
+		restorePrivateEditorCursor(this, hit.ci, hit.slashIndex + hit.replacement.length);
+	}
+}
+
+export function setupSkillAutocomplete(ctx: ExtensionContext, getSkills: () => SkillAutocompleteSkill[]): void {
+	ctx.ui.addAutocompleteProvider((current): AutocompleteProvider => ({
+		async getSuggestions(lines, cursorLine, cursorCol, options): Promise<AutocompleteSuggestions | null> {
+			const currentLine = lines[cursorLine] ?? "";
+			const hit = slashTokenAtCursor(currentLine, cursorCol);
+			if (!hit) return current.getSuggestions(lines, cursorLine, cursorCol, options);
+			const items = fuzzyFilter(getSkills(), hit.query, (skill) => skill.name).map(skillAutocompleteItem);
+			if (items.length === 0) return current.getSuggestions(lines, cursorLine, cursorCol, options);
+			return { items, prefix: hit.prefix };
+		},
+		applyCompletion(lines, cursorLine, cursorCol, item, prefix) {
+			const currentLine = lines[cursorLine] ?? "";
+			const token = slashTokenAtCursor(currentLine, cursorCol);
+			const start = token?.start ?? cursorCol - prefix.length;
+			const end = token?.end ?? cursorCol;
+			const insertion = `/${item.value} `;
+			const newLines = [...lines];
+			newLines[cursorLine] = currentLine.slice(0, start) + insertion + currentLine.slice(end);
+			return { lines: newLines, cursorLine, cursorCol: start + insertion.length };
+		},
+		shouldTriggerFileCompletion(lines, cursorLine, cursorCol) {
+			return current.shouldTriggerFileCompletion?.(lines, cursorLine, cursorCol) ?? true;
+		},
+	}));
+
+	ctx.ui.setEditorComponent(
+		(tui: TUI, theme: EditorTheme, keybindings: KeybindingsManager): EditorComponent =>
+			new SkillGhostEditor(tui, theme, keybindings, getSkills),
+	);
+}

--- a/tests/expand-inline-skills.test.ts
+++ b/tests/expand-inline-skills.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from "bun:test";
+import { expandInlineSkills, type InlineSkillRef } from "../index";
+
+/**
+ * `expandInlineSkills` lets one message reference multiple skills: the leading
+ * `/skill:<name>` is left for pi core, and every additional resolvable token is
+ * replaced *in place* with a `<skill>` XML block (the same shape core emits).
+ * In-place replacement preserves the user's text ordering and keeps the leading
+ * `/skill:` at index 0 so core still owns the leading skill. These tests pin
+ * that contract with a fake resolver and body reader (no filesystem).
+ */
+
+function ref(name: string): InlineSkillRef {
+	return { name, filePath: `/skills/${name}/SKILL.md`, baseDir: `/skills/${name}` };
+}
+
+function harness(skills: string[], bodies: Record<string, string> = {}) {
+	const known = new Set(skills);
+	return (text: string) =>
+		expandInlineSkills(
+			text,
+			(name) => (known.has(name) ? ref(name) : undefined),
+			(skill) => bodies[skill.name] ?? `# ${skill.name}`,
+		);
+}
+
+describe("expandInlineSkills leading skill", () => {
+	it("is a no-op when only a single leading skill is referenced (core owns it)", () => {
+		const expand = harness(["code-simplifier"]);
+		expect(expand("/skill:code-simplifier do stuff")).toBeUndefined();
+	});
+
+	it("is a no-op when there are no skill tokens at all", () => {
+		const expand = harness(["code-simplifier"]);
+		expect(expand("just a normal message")).toBeUndefined();
+	});
+});
+
+describe("expandInlineSkills in-place replacement + ordering", () => {
+	it("replaces a non-leading token in place and keeps the leading skill for core", () => {
+		const expand = harness(["code-simplifier", "write-a-skill"], {
+			"write-a-skill": "Write skills well.",
+		});
+		const result = expand("/skill:code-simplifier /skill:write-a-skill hi");
+
+		expect(result).not.toBeUndefined();
+		expect(result!.text.startsWith("/skill:code-simplifier")).toBe(true); // leading preserved
+		expect(result!.text).not.toContain("/skill:write-a-skill"); // token replaced
+		expect(result!.text).toContain("hi"); // trailing text preserved
+		expect(result!.text).toContain(
+			'<skill name="write-a-skill" location="/skills/write-a-skill/SKILL.md">\nReferences are relative to /skills/write-a-skill.\n\nWrite skills well.\n</skill>',
+		);
+		expect(result!.injected).toEqual(["write-a-skill"]);
+	});
+
+	it("preserves text ordering: trailing text stays AFTER an injected skill block", () => {
+		// Regression for the append-strategy bug that relocated trailing text.
+		const expand = harness(["how-to-code", "tdd"]);
+		const result = expand("/skill:how-to-code I need you to say `hi` /skill:tdd and nothing else");
+
+		const tddBlock = result!.text.indexOf('<skill name="tdd"');
+		const trailing = result!.text.indexOf("and nothing else");
+		expect(tddBlock).toBeGreaterThan(-1);
+		expect(trailing).toBeGreaterThan(tddBlock); // trailing text comes AFTER the block
+		expect(result!.text).toContain("I need you to say `hi`");
+		expect(result!.text.startsWith("/skill:how-to-code ")).toBe(true);
+	});
+
+	it("injects multiple additional skills in mention order, preserving interleaved text", () => {
+		const expand = harness(["a", "b", "c"]);
+		const result = expand("/skill:a /skill:b text /skill:c");
+
+		expect(result!.injected).toEqual(["b", "c"]);
+		const bBlock = result!.text.indexOf('<skill name="b"');
+		const textWord = result!.text.indexOf("text");
+		const cBlock = result!.text.indexOf('<skill name="c"');
+		expect(bBlock).toBeGreaterThan(-1);
+		expect(textWord).toBeGreaterThan(bBlock); // 'text' after b block
+		expect(cBlock).toBeGreaterThan(textWord); // c block after 'text'
+		expect(result!.text.startsWith("/skill:a ")).toBe(true);
+	});
+
+	it("expands all tokens when the message does not start with /skill: (core expands nothing)", () => {
+		const expand = harness(["a", "b"]);
+		const result = expand("hello /skill:a and /skill:b");
+
+		expect(result!.injected).toEqual(["a", "b"]);
+		expect(result!.text.startsWith("hello")).toBe(true);
+		expect(result!.text).not.toContain("/skill:");
+	});
+});
+
+describe("expandInlineSkills decoration (<skill_context>)", () => {
+	it("passes the body through decorate and uses its result as the block inner content", () => {
+		const known = new Set(["tdd"]);
+		const result = expandInlineSkills(
+			"/skill:how-to-code /skill:tdd hi",
+			(name) => (known.has(name) ? ref(name) : undefined),
+			() => "BODY",
+			(body) => `<skill_context>CTX</skill_context>\n\n${body}`,
+		);
+		expect(result!.text).toContain(
+			'<skill name="tdd" location="/skills/tdd/SKILL.md">\nReferences are relative to /skills/tdd.\n\n<skill_context>CTX</skill_context>\n\nBODY\n</skill>',
+		);
+	});
+
+	it("omits decoration when no decorate callback is supplied", () => {
+		const expand = harness(["tdd"], { tdd: "BODY" });
+		const result = expand("/skill:lead /skill:tdd hi");
+		expect(result!.text).not.toContain("<skill_context>");
+		expect(result!.text).toContain("\n\nBODY\n</skill>");
+	});
+});
+
+describe("expandInlineSkills unknown / unreadable skills", () => {
+	it("leaves unknown skill tokens verbatim and injects nothing", () => {
+		const expand = harness(["known"]);
+		const result = expand("hi /skill:unknown");
+		expect(result).toBeUndefined();
+	});
+
+	it("leaves a token whose body read throws verbatim", () => {
+		const known = new Set(["good", "bad", "broken"]);
+		const result = expandInlineSkills(
+			"/skill:good /skill:bad /skill:broken hi",
+			(name) => (known.has(name) ? ref(name) : undefined),
+			(skill) => {
+				if (skill.name === "broken") throw new Error("boom");
+				return `${skill.name} body`;
+			},
+		);
+		expect(result).not.toBeUndefined();
+		expect(result!.injected).toEqual(["bad"]); // good is leading (skipped), broken threw
+		expect(result!.text).toContain("/skill:broken"); // verbatim
+		expect(result!.text).not.toContain("/skill:bad"); // replaced
+		expect(result!.text.startsWith("/skill:good")).toBe(true); // leading preserved
+	});
+});
+
+describe("expandInlineSkills token boundaries", () => {
+	it("does not match /skill: embedded in a path or URL", () => {
+		const expand = harness(["x"]);
+		const result = expand("see foo/skill:x and /skill:x real");
+		expect(result).not.toBeUndefined();
+		expect(result!.text).toContain("foo/skill:x"); // embedded left as-is
+		expect(result!.text).not.toContain("/skill:x real"); // boundary token replaced
+	});
+});

--- a/tests/skill-autocomplete.test.ts
+++ b/tests/skill-autocomplete.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "bun:test";
+import type { AutocompleteProvider } from "@earendil-works/pi-tui";
+import { setupSkillAutocomplete, type SkillAutocompleteSkill } from "../skill-autocomplete";
+
+/**
+ * `setupSkillAutocomplete` installs two things on `ctx.ui`:
+ *   - an autocomplete provider factory (popup path), and
+ *   - a custom editor factory (inline ghost path).
+ *
+ * These tests drive that registration through a fake `ctx.ui` and a wrapped
+ * "current" provider so observable behavior is locked without spinning up a
+ * real terminal/editor (the ghost render + cursor poke is deliberately left to
+ * live smoke; it is author-marked version-sensitive).
+ */
+
+type FakeCtxOptions = { hasExistingEditor?: boolean };
+
+function createFakeCtx(options: FakeCtxOptions = {}) {
+	let providerFactory: ((current: AutocompleteProvider) => AutocompleteProvider) | undefined;
+	let editorFactory: unknown;
+	const ctx = {
+		ui: {
+			addAutocompleteProvider(factory: (current: AutocompleteProvider) => AutocompleteProvider): void {
+				providerFactory = factory;
+			},
+			getEditorComponent(): unknown {
+				return options.hasExistingEditor ? (() => "existing-editor") : undefined;
+			},
+			setEditorComponent(factory: unknown): void {
+				editorFactory = factory;
+			},
+		},
+	} as any;
+
+	return {
+		ctx,
+		getProviderFactory: () => providerFactory,
+		getEditorFactory: () => editorFactory,
+	};
+}
+
+// Wrapped "current" provider returns sentinels so delegation is observable.
+const DELEGATED_SUGGESTIONS = { items: [{ value: "builtin", label: "builtin" }], prefix: "current" };
+const DELEGATED_APPLY = { lines: ["DELEGATED"], cursorLine: 0, cursorCol: 9 };
+
+function createWrappedCurrent(): AutocompleteProvider {
+	return {
+		async getSuggestions() {
+			return DELEGATED_SUGGESTIONS;
+		},
+		applyCompletion() {
+			return DELEGATED_APPLY;
+		},
+		shouldTriggerFileCompletion() {
+			return false;
+		},
+	};
+}
+
+function buildProvider(getSkills: () => SkillAutocompleteSkill[]): AutocompleteProvider {
+	const env = createFakeCtx();
+	setupSkillAutocomplete(env.ctx, getSkills);
+	const factory = env.getProviderFactory();
+	if (!factory) throw new Error("autocomplete provider was not registered");
+	return factory(createWrappedCurrent());
+}
+
+async function suggest(provider: AutocompleteProvider, line: string, col: number = line.length, cursorLine = 0) {
+	// Build a lines array where index `cursorLine` is the active line.
+	const lines = cursorLine === 0 ? [line] : [...Array(cursorLine).fill(""), line];
+	return provider.getSuggestions(lines, cursorLine, col, { signal: new AbortController().signal });
+}
+
+const skills = (names: string[]): SkillAutocompleteSkill[] => names.map((name) => ({ name }));
+
+describe("setupSkillAutocomplete registration", () => {
+	it("registers an autocomplete provider and a ghost editor when no editor is installed", () => {
+		const env = createFakeCtx();
+		setupSkillAutocomplete(env.ctx, () => []);
+
+		expect(env.getProviderFactory()).toBeDefined();
+		expect(env.getEditorFactory()).toBeDefined();
+	});
+
+	it("does not clobber an existing custom editor but still registers the popup provider", () => {
+		const env = createFakeCtx({ hasExistingEditor: true });
+		setupSkillAutocomplete(env.ctx, () => []);
+
+		expect(env.getProviderFactory()).toBeDefined();
+		expect(env.getEditorFactory()).toBeUndefined();
+	});
+});
+
+describe("skill autocomplete suggestions", () => {
+	it("returns the single matching skill for a unique mid-text prefix", async () => {
+		const provider = buildProvider(() => skills(["smoke-unique", "smoke-alpha"]));
+		const result = await suggest(provider, "run /smoke-u");
+
+		expect(result).not.toBeNull();
+		expect(result!.items.map((item) => item.value)).toEqual(["skill:smoke-unique"]);
+		expect(result!.prefix).toBe("/smoke-u");
+	});
+
+	it("surfaces every prefix match for an ambiguous token (popup path)", async () => {
+		const provider = buildProvider(() => skills(["smoke-alpha", "smoke-alpine", "smoke-unique"]));
+		const result = await suggest(provider, "run /smoke-a");
+
+		expect(result).not.toBeNull();
+		expect(result!.items.map((item) => item.value).sort()).toEqual(["skill:smoke-alpha", "skill:smoke-alpine"]);
+	});
+
+	it("strips a typed /skill: prefix before matching", async () => {
+		const provider = buildProvider(() => skills(["smoke-unique", "smoke-alpha"]));
+		const result = await suggest(provider, "run /skill:smoke-u");
+
+		expect(result).not.toBeNull();
+		expect(result!.items.map((item) => item.value)).toEqual(["skill:smoke-unique"]);
+		expect(result!.prefix).toBe("/skill:smoke-u");
+	});
+
+	it("delegates to the wrapped provider when the slash starts the message", async () => {
+		const provider = buildProvider(() => skills(["smoke-unique"]));
+		const result = await suggest(provider, "/smoke-u");
+
+		expect(result).toEqual(DELEGATED_SUGGESTIONS);
+	});
+
+	it("suggests a skill for a bare /skill: at the start of a NON-first line (no built-in menu there)", async () => {
+		const provider = buildProvider(() => skills(["smoke-unique"]));
+		// cursorLine 1 (a later line); the line itself starts with the slash
+		const result = await suggest(provider, "/smoke-u", "/smoke-u".length, 1);
+
+		expect(result).not.toEqual(DELEGATED_SUGGESTIONS);
+		expect(result?.items.map((item) => item.value)).toEqual(["skill:smoke-unique"]);
+		expect(result?.prefix).toBe("/smoke-u");
+	});
+
+	it("delegates when the slash is inside a URL", async () => {
+		const provider = buildProvider(() => skills(["smoke-unique"]));
+		const result = await suggest(provider, "see http://smoke-u");
+
+		expect(result).toEqual(DELEGATED_SUGGESTIONS);
+	});
+
+	it("delegates when no skill matches the token", async () => {
+		const provider = buildProvider(() => skills(["smoke-unique"]));
+		const result = await suggest(provider, "run /zzzz");
+
+		expect(result).toEqual(DELEGATED_SUGGESTIONS);
+	});
+
+	it("delegates when the cursor is past the end of the token", async () => {
+		const provider = buildProvider(() => skills(["smoke-unique"]));
+		const result = await suggest(provider, "run /smoke-u tail");
+
+		expect(result).toEqual(DELEGATED_SUGGESTIONS);
+	});
+});
+
+describe("skill autocomplete applyCompletion", () => {
+	it("inserts /skill:<name> with a trailing space and moves the cursor after it", () => {
+		const provider = buildProvider(() => skills(["smoke-unique"]));
+		const line = "run /smoke-u";
+		const result = provider.applyCompletion([line], 0, line.length, { value: "skill:smoke-unique", label: "skill:smoke-unique" }, "/smoke-u");
+
+		expect(result.lines).toEqual(["run /skill:smoke-unique "]);
+		expect(result.cursorLine).toBe(0);
+		expect(result.cursorCol).toBe("run /skill:smoke-unique ".length);
+	});
+
+	it("normalizes a typed /skill: prefix on insertion", () => {
+		const provider = buildProvider(() => skills(["smoke-unique"]));
+		const line = "run /skill:smoke-u";
+		const result = provider.applyCompletion([line], 0, line.length, { value: "skill:smoke-unique", label: "skill:smoke-unique" }, "/skill:smoke-u");
+
+		expect(result.lines).toEqual(["run /skill:smoke-unique "]);
+		expect(result.cursorCol).toBe("run /skill:smoke-unique ".length);
+	});
+
+	it("delegates non-skill items to the wrapped provider", () => {
+		const provider = buildProvider(() => skills(["smoke-unique"]));
+		const result = provider.applyCompletion(["run /smoke-u"], 0, "run /smoke-u".length, { value: "builtin", label: "builtin" }, "/smoke-u");
+
+		expect(result).toEqual(DELEGATED_APPLY);
+	});
+});


### PR DESCRIPTION
## Summary

Adds `/skill:<name>` completion when the slash is typed **after other text**. pi's built-in slash menu only triggers when `/` is the first character of the message, so today there is no way to get skill completion mid-sentence. This branch closes that gap with two complementary surfaces, both kept strictly out of the skill-resolution core.

It is a strict superset of existing behavior: nothing about how skills are resolved, injected, or run changes. `index.ts` is **+40 lines, 0 deletions**.

## Why

Two user-visible problems:

1. **No completion mid-text.** `/skill:` commands only complete at the start of the input. Typing `run /rese` (or any command mid-message) gets no help.
2. **Package-installed skills are invisible to discovery.** Skills that ship via `pi install git:...` (e.g. `ponytail-review`) live under `~/.pi/agent/git/...`, which `refreshSkills` did not scan, so they never appeared in any completion list.

## What ships

### `skill-autocomplete.ts` (new, 199 lines)

Self-contained module. Depends only on a `{ name: string }` view of a skill — never on `SkillRecord`, `filePath`, or `globs` — so resolution and UI stay decoupled.

- **Popup provider** — `ctx.ui.addAutocompleteProvider`. Matches a `/token` at a whitespace boundary (mid-text only; start-of-message is left to pi's built-in menu) and returns fuzzy-matched skills. Ambiguous tokens surface here.
- **Inline ghost text** — a `CustomEditor` subclass renders the name *continuation* dim ahead of the cursor for an unambiguous prefix match. **Tab or Right Arrow** accept it into `/skill:<name> `. Cursor sits on the first ghost character (fish-shell style); the remainder is muted gray (`\x1b[2;38;5;244m`). Any ambiguity, non-end cursor, or render-format mismatch fails safe to the popup.
- **Acceptance** — `Right Arrow` added alongside `Tab` (standard shell behavior).

### `index.ts` (additive only, +40 / -0)

- One new import + one new state var (`skillList`, cached on `refreshSkills`).
- `refreshSkills` extended: in addition to the existing three roots, it now scans active package roots from the pi settings file, restricted to `<pkg>/skills/**` and `<pkg>/SKILL.md`. This **adds** package skills to the available set; it never removes or alters any. Roots are parsed once per session (memoized).
- `session_start` gets a single `setupSkillAutocomplete(ctx, () => skillList)` call.

### `package.json`

- Declares this as a pi package (`pi.extensions: ["./index.ts"]`), adds the `pi-package` keyword, peer-depends on the two `@earendil-works` packages, and externalizes them in the `build` script.

## What is **not** touched

To make review easy, the resolution/runtime path is byte-identical to `master`:

- `insertSkillContext` / `skillContextBlock` / the `<skill_context>` block
- `rewriteCommand`, `resolveSkillResource`, `resolveRelativeResource`, sibling-skill `../exa/...` fixup
- `executeDynamicShell`, `runDynamicCommand`, `isTrustedForDynamicShell`
- path-variable substitution and the bash `PI_SKILL_DIR` block/retry logic
- the `tool_call` (bash + read) and `tool_result` handlers, globs auto-injection, model/thinking overrides
- the `<agent_skills>` system-prompt block in `before_agent_start`

## Review process

This was reviewed three times, each by a separate `zai/glm-5.2` reviewer with a specific lens:

| Lens | Verdict | Outcome |
|---|---|---|
| `thermo-nuclear-code-quality-review` | fix-first → clean | Dead match-tiebreak logic removed (plain count); ANSI-splice coupling documented; settings parse memoized |
| `ponytail-review` | `-3 lines` | Dropped `truncateToWidth`/`visibleWidth` (ASCII slug → `1 char = 1 col`); simplified the match conditional |
| `ponytail-debt` | 0 markers → 3 | Added `// ponytail:` markers on the highest-rot deferrals |

Findings I deliberately did **not** apply, with reasoning:
- **Drop defensive normalization in `packageRootFromSource`** — kept. Package-path parsing is near a trust boundary; ponytail's own rule is to not simplify away validation there.
- **Stop filesystem rescanning after the first prompt** — not applied. It trades startup-time autocomplete availability for fewer scans; kept as a judgment call open to the maintainer.

## Deliberate simplifications (marked, not hidden)

Three `// ponytail:` markers name a ceiling and an upgrade path:

1. `restorePrivateEditorCursor` — pi's `Editor` has no public `setCursor(line, col)`; this pokes a private field. Upgrade when pi-tui exposes one.
2. `packageRootFromSource` — hand-rolls pi's package cache layout (github.com git specs only). Upgrade to an extension API exposing active skill roots when one exists.
3. Ghost `render()` — splices into pi's end-of-line cursor block; coupled to pi-tui's render format, fails safe. Upgrade to a first-class inline-completion API.

## Verification

```bash
NODE_PATH=<pi node_modules> bun run build      # bundles, 9 modules
bun test                                        # 22 pass, 0 fail
tsc --noEmit (strict)                           # exit 0
```

Runtime smoke (behavior asserted identical pre/post):

- `/improve-c` → ghost `debase-architecture` → Tab → `/skill:improve-codebase-architecture `
- `/ponytail-r` → ghost `view` → Tab/Right → `/skill:ponytail-review `
- `/thermo` → ghost `nuclear-code-quality-review`
- `/rese` → ghost `rch` → `/skill:research `
- `/ponytail` (6 matches) → **no ghost**, Tab does not mutate → falls through to popup
- Stale cached skills (`autoresearch-create`, `pi-interactive-shell`) correctly excluded by the narrowed package scan
- Actual `SKILL.md` reads still get `<skill_context>` + `<path_policy>` + correct `<skill_dir>` injected

## Breaking changes

None. Discovery finds more skills; resolution, injection, and execution are unchanged.

## Out of scope / follow-ups

- A real inline-completion API in pi-tui would let us delete the ANSI splicing and the cursor-state poke (the two `// ponytail:`-marked version-sensitive spots).
- mtime-gating the filesystem rescan if the skill count ever makes it noticeable.
- Non-github git hosts for pre-prompt discovery (the authoritative `before_agent_start` set still covers them at runtime).
