### PR TITLE
fix(skills): keep skill name inline instead of leaving a gap

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -181,11 +181,17 @@ function isOrdinarySingleLeadingSkillCommand(text: string, skills: InlineSkillDi
 }
 
 /**
- * Remove resolvable `/skill:<name>` tokens from user text and return them as
- * separate skill-display records. By default the leading token is skipped so pi
- * core can keep handling ordinary single-skill commands. Pass
- * `includeLeading: true` when the extension owns the whole multi-skill prompt.
- * Unknown or unreadable skills are left verbatim so core/pi can report them.
+ * Replace resolvable `/skill:<name>` tokens in user text with the bare skill
+ * `name`, and return the referenced skills as separate skill-display records.
+ * Leaving the bare name keeps the user's sentence readable (no gap) while the
+ * skill body is rendered as its own `[skill]` row above the prompt. Replacing
+ * (rather than keeping) the `/skill:` sigil also stops pi core from
+ * double-expanding a leading token, since the text no longer starts with it.
+ *
+ * By default the leading token is skipped so pi core can keep handling ordinary
+ * single-skill commands. Pass `includeLeading: true` when the extension owns the
+ * whole multi-skill prompt. Unknown or unreadable skills are left verbatim so
+ * core/pi can report them.
  *
  * `decorate`, if provided, wraps the skill body (e.g. with `<skill_context>`);
  * it receives the body and must return the inner content of the `<skill>` block.
@@ -205,8 +211,8 @@ export function extractInlineSkillDisplays(
 	});
 	if (matches.length === 0) return undefined;
 
-	type Removal = { start: number; end: number };
-	const removals: Removal[] = [];
+	type Replacement = { start: number; end: number; name: string };
+	const replacements: Replacement[] = [];
 	const skills: InlineSkillDisplay[] = [];
 
 	for (const match of matches) {
@@ -224,16 +230,16 @@ export function extractInlineSkillDisplays(
 
 		const inner = decorate ? decorate(body, skill) : body;
 		skills.push(formatInlineSkillDisplay(skill, inner));
-		removals.push({ start, end: start + match[0].length });
+		replacements.push({ start, end: start + match[0].length, name: skill.name });
 	}
 
-	if (removals.length === 0) return undefined;
+	if (replacements.length === 0) return undefined;
 
-	removals.sort((a, b) => a.start - b.start);
+	replacements.sort((a, b) => a.start - b.start);
 	let out = "";
 	let cursor = 0;
-	for (const { start, end } of removals) {
-		out += text.slice(cursor, start);
+	for (const { start, end, name } of replacements) {
+		out += text.slice(cursor, start) + name;
 		cursor = end;
 	}
 	out += text.slice(cursor);

--- a/tests/expand-inline-skills.test.ts
+++ b/tests/expand-inline-skills.test.ts
@@ -36,7 +36,7 @@ describe("extractInlineSkillDisplays leading skill", () => {
 });
 
 describe("extractInlineSkillDisplays visible prompt cleanup", () => {
-	it("can extract the leading skill when the extension owns a multi-skill prompt", () => {
+	it("replaces leading tokens with bare names when the extension owns a multi-skill prompt", () => {
 		const extract = harness(["torpathy", "ask-matt"]);
 		const result = extractInlineSkillDisplays(
 			"/skill:torpathy what's the best architecture? /skill:ask-matt",
@@ -47,7 +47,7 @@ describe("extractInlineSkillDisplays visible prompt cleanup", () => {
 		);
 
 		expect(result!.skills.map((skill) => skill.name)).toEqual(["torpathy", "ask-matt"]);
-		expect(result!.text).toBe("what's the best architecture?");
+		expect(result!.text).toBe("torpathy what's the best architecture? ask-matt");
 	});
 
 	it("removes a non-leading token and keeps the leading skill for core by default", () => {
@@ -96,6 +96,30 @@ describe("extractInlineSkillDisplays visible prompt cleanup", () => {
 		expect(result!.skills.map((skill) => skill.name)).toEqual(["a", "b"]);
 		expect(result!.text.startsWith("hello")).toBe(true);
 		expect(result!.text).not.toContain("/skill:");
+	});
+});
+
+describe("extractInlineSkillDisplays bare-name substitution", () => {
+	it("replaces a mid-text token with the bare skill name so the sentence stays whole", () => {
+		const extract = harness(["improve-codebase-architecture", "grill-with-docs"]);
+		const result = extract(
+			"using the /skill:improve-codebase-architecture along with /skill:grill-with-docs let's improve",
+		);
+
+		expect(result!.text).toBe(
+			"using the improve-codebase-architecture along with grill-with-docs let's improve",
+		);
+		expect(result!.skills.map((skill) => skill.name)).toEqual([
+			"improve-codebase-architecture",
+			"grill-with-docs",
+		]);
+	});
+
+	it("leaves no whitespace gap for a single mid-text reference", () => {
+		const extract = harness(["diagnosing-bugs"]);
+		const result = extract("I added the skill /skill:diagnosing-bugs inline here");
+
+		expect(result!.text).toBe("I added the skill diagnosing-bugs inline here");
 	});
 });
 


### PR DESCRIPTION
## Summary

Pi core only expands a single **leading** `/skill:<name>` token. This extension handles every *other* skill reference in a message by lifting it into its own `[skill]` row. The problem: it did that by **deleting** the `/skill:<name>` token from your prompt — which left a double-space hole where the words used to be and dropped the skill name entirely, so the text the model received read as a half-finished sentence.

This PR keeps the **bare skill name** in place instead of deleting the token.

## Before / After

A normal request that leans on two skills:

```
scaffold the login form with /skill:shadcn and write the tests with /skill:tdd
```

**Before** — tokens removed, sentence falls apart:

```
┌ [skill] shadcn   ▸ (collapsed body)
├ [skill] tdd      ▸ (collapsed body)
└ you: scaffold the login form with  and write the tests with
                                    ^^                         ^← trails off, holes where the skills were
```

**After** — tokens replaced with the bare name, request still reads as written:

```
┌ [skill] shadcn   ▸ (collapsed body)
├ [skill] tdd      ▸ (collapsed body)
└ you: scaffold the login form with shadcn and write the tests with tdd
```

The `[skill]` rows are unchanged — full skill bodies still load above the prompt and reach both the TUI and the model. Only the user-text rewrite changed.

### More cases

| You type | Before (sent to model) | After (sent to model) |
|----------|------------------------|------------------------|
| `add a rate limiter using /skill:tdd please` | `add a rate limiter using  please` | `add a rate limiter using tdd please` |
| `the checkout test is flaky, can you /skill:diagnosing-bugs it` | `the checkout test is flaky, can you  it` | `the checkout test is flaky, can you diagnosing-bugs it` |
| `/skill:tdd add the password reset endpoint` *(single leading)* | `add the password reset endpoint` — core expands inline *(unchanged)* | `add the password reset endpoint` — core expands inline *(unchanged)* |

## Why this is the right fix

- **One stroke, two problems.** Stripping the `/skill:` sigil means the prompt no longer *starts* with `/skill:`, so Pi core (`_expandSkillCommand`, which only acts on a leading token) won't double-expand a leading skill. The gap fix and the double-expansion guard fall out of the same change.
- **Minimal diff, no new branching.** A one-field rename (`Removal` → `Replacement`, carrying the resolved skill name) plus appending the name in the existing splice loop.
- **Bare name, by design.** Plain prose reads naturally and matches the row title above it; no sigils or markers reintroduced. Reload risk is unchanged — the body is already loaded in the row, so the bare name is just a reference to it.

## Tests

- Updated the multi-skill prompt test for the new bare-name output.
- Added coverage for single and multi mid-text references: bare name present, no whitespace gap, `[skill]` rows still emitted in order.
- Full suite: **52 passing.**

## Review

Reviewed under both `thermo-nuclear-code-quality-review` and `ponytail-review` — both approved. Trivial redundancies (a comment restating the doc, two tautological assertions) were cut.

## Follow-up (out of scope)

`extractInlineSkillDisplays`'s `includeLeading` option now has a default branch production never exercises — the sole caller always passes `includeLeading: true` and guards ordinary single-skill commands separately. A later cleanup could delete the option and let the caller's guard be the single source of truth. Kept out of this PR to preserve a focused diff.
