### PR TITLE
fix(skills): stop steered skill prompts from firing before their message

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -185,6 +185,26 @@ export function inlineSkillsIntoText(text: string, skills: InlineSkillDisplay[])
 	return blocks ? `${blocks}\n\n${text}` : text;
 }
 
+/**
+ * Decide how extracted skills are delivered alongside the cleaned user text.
+ *
+ * Idle: skills ride as separate custom messages (rendered as collapsible
+ * `[skill]` rows) that land in the same turn as the user prompt.
+ *
+ * Streaming: steer/followUp queues drain one entry at a time by default, so a
+ * separate skill message would be delivered alone in its own turn and invoked
+ * before the user's queued text arrives. Inline the blocks into the single
+ * transformed text instead (no `[skill]` row, but skill + instruction stay
+ * together). This is the seam the streaming regression turns on.
+ */
+export function planInlineSkillDelivery(
+	result: { text: string; skills: InlineSkillDisplay[] },
+	streaming: boolean,
+): { text: string; messages: InlineSkillDisplay[] } {
+	if (streaming) return { text: inlineSkillsIntoText(result.text, result.skills), messages: [] };
+	return { text: result.text, messages: result.skills };
+}
+
 function isOrdinarySingleLeadingSkillCommand(text: string, skills: InlineSkillDisplay[]): boolean {
 	if (skills.length !== 1) return false;
 	const token = `/skill:${skills[0].name}`;
@@ -701,19 +721,12 @@ export default function skillRelativePaths(pi: ExtensionAPI) {
 		);
 		if (!result || isOrdinarySingleLeadingSkillCommand(event.text, result.skills)) return;
 
-		// While streaming, steer/followUp queues drain one entry at a time by default,
-		// so a separate skill message would be delivered alone in its own turn and the
-		// skill invoked before the user's queued text arrives. Inline the skill blocks
-		// into the single queued message so they travel together.
-		if (event.streamingBehavior) {
-			return { action: "transform" as const, text: inlineSkillsIntoText(result.text, result.skills) };
-		}
-
-		for (const skill of result.skills) {
+		const { text, messages } = planInlineSkillDelivery(result, Boolean(event.streamingBehavior));
+		for (const skill of messages) {
 			pi.sendMessage(inlineSkillMessage(skill));
 		}
 
-		return { action: "transform" as const, text: result.text };
+		return { action: "transform" as const, text };
 	});
 
 	pi.on("turn_start", async () => {

--- a/index.ts
+++ b/index.ts
@@ -196,12 +196,22 @@ export function inlineSkillsIntoText(text: string, skills: InlineSkillDisplay[])
  * before the user's queued text arrives. Inline the blocks into the single
  * transformed text instead (no `[skill]` row, but skill + instruction stay
  * together). This is the seam the streaming regression turns on.
+ *
+ * Exception: if the cleaned prompt still starts with a slash-command (e.g. a
+ * leading prompt-template `/tmpl ...`), it must stay at position 0 so pi core's
+ * prompt-template expansion (which requires `text.startsWith("/")` and replaces
+ * the whole message) still fires. Prepending skill XML would bury it. In that
+ * rare template+skill combo we fall back to separate skill messages: the
+ * template keeps expanding, and the skills may split across one-at-a-time drains
+ * as they did before this fix.
  */
 export function planInlineSkillDelivery(
 	result: { text: string; skills: InlineSkillDisplay[] },
 	streaming: boolean,
 ): { text: string; messages: InlineSkillDisplay[] } {
-	if (streaming) return { text: inlineSkillsIntoText(result.text, result.skills), messages: [] };
+	if (streaming && !result.text.startsWith("/")) {
+		return { text: inlineSkillsIntoText(result.text, result.skills), messages: [] };
+	}
 	return { text: result.text, messages: result.skills };
 }
 
@@ -722,8 +732,9 @@ export default function skillRelativePaths(pi: ExtensionAPI) {
 		if (!result || isOrdinarySingleLeadingSkillCommand(event.text, result.skills)) return;
 
 		const { text, messages } = planInlineSkillDelivery(result, Boolean(event.streamingBehavior));
+		const options = event.streamingBehavior ? { deliverAs: event.streamingBehavior } : undefined;
 		for (const skill of messages) {
-			pi.sendMessage(inlineSkillMessage(skill));
+			pi.sendMessage(inlineSkillMessage(skill), options);
 		}
 
 		return { action: "transform" as const, text };

--- a/index.ts
+++ b/index.ts
@@ -173,6 +173,18 @@ function inlineSkillMessage(skill: InlineSkillDisplay): {
 	};
 }
 
+/**
+ * Combine extracted skill blocks with the cleaned user text into a single string.
+ * Used for steer/followUp delivery: the steering queue defaults to
+ * "one-at-a-time", so separate skill messages would each drain in their own turn
+ * and the skill body would be invoked before the user's text ever arrives. Keeping
+ * them in one queued entry makes the skill and the instruction travel together.
+ */
+export function inlineSkillsIntoText(text: string, skills: InlineSkillDisplay[]): string {
+	const blocks = skills.map((skill) => skill.block).join("\n\n");
+	return blocks ? `${blocks}\n\n${text}` : text;
+}
+
 function isOrdinarySingleLeadingSkillCommand(text: string, skills: InlineSkillDisplay[]): boolean {
 	if (skills.length !== 1) return false;
 	const token = `/skill:${skills[0].name}`;
@@ -689,9 +701,16 @@ export default function skillRelativePaths(pi: ExtensionAPI) {
 		);
 		if (!result || isOrdinarySingleLeadingSkillCommand(event.text, result.skills)) return;
 
-		const deliverAs = event.streamingBehavior;
+		// While streaming, steer/followUp queues drain one entry at a time by default,
+		// so a separate skill message would be delivered alone in its own turn and the
+		// skill invoked before the user's queued text arrives. Inline the skill blocks
+		// into the single queued message so they travel together.
+		if (event.streamingBehavior) {
+			return { action: "transform" as const, text: inlineSkillsIntoText(result.text, result.skills) };
+		}
+
 		for (const skill of result.skills) {
-			pi.sendMessage(inlineSkillMessage(skill), { deliverAs });
+			pi.sendMessage(inlineSkillMessage(skill));
 		}
 
 		return { action: "transform" as const, text: result.text };

--- a/tests/expand-inline-skills.test.ts
+++ b/tests/expand-inline-skills.test.ts
@@ -201,6 +201,25 @@ describe("planInlineSkillDelivery (the streaming-regression seam)", () => {
 		expect(plan.text).toBe(result.text);
 		expect(plan.text).not.toContain("a body");
 	});
+
+	it("streaming with a leading slash-command: does NOT inline, so core can still expand it", () => {
+		// e.g. `/tmpl arg /skill:a` -> cleaned text `/tmpl arg a`. Prepending skill XML
+		// would move the leading `/tmpl` off position 0 and defeat core's prompt-template
+		// expansion (which requires text.startsWith("/")). Fall back to separate messages.
+		const result = extractInlineSkillDisplays(
+			"/tmpl arg /skill:a",
+			(name) => (name === "a" ? ref(name) : undefined),
+			(skill) => `${skill.name} body`,
+			undefined,
+			{ includeLeading: true },
+		)!;
+		expect(result.text).toBe("/tmpl arg a");
+
+		const plan = planInlineSkillDelivery(result, true);
+		expect(plan.text).toBe("/tmpl arg a"); // leading token preserved at position 0
+		expect(plan.messages).toBe(result.skills); // skill delivered as a separate message
+		expect(plan.text.startsWith("/")).toBe(true);
+	});
 });
 
 describe("extractInlineSkillDisplays unknown / unreadable skills", () => {

--- a/tests/expand-inline-skills.test.ts
+++ b/tests/expand-inline-skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { extractInlineSkillDisplays, type InlineSkillRef } from "../index";
+import { extractInlineSkillDisplays, inlineSkillsIntoText, type InlineSkillRef } from "../index";
 
 /**
  * `extractInlineSkillDisplays` lets one message reference multiple skills without
@@ -142,6 +142,31 @@ describe("extractInlineSkillDisplays decoration (<skill_context>)", () => {
 		const result = extract("/skill:lead /skill:tdd hi");
 		expect(result!.skills[0].block).not.toContain("<skill_context>");
 		expect(result!.skills[0].block).toContain("\n\nBODY\n</skill>");
+	});
+});
+
+describe("inlineSkillsIntoText (steer/followUp single-entry delivery)", () => {
+	// Regression: during streaming the steering queue drains one entry at a time,
+	// so skills must ride inside the same queued message as the user text — never
+	// as separate messages that would invoke the skill in its own earlier turn.
+	it("prepends every skill block before the user text as one string", () => {
+		const result = extractInlineSkillDisplays(
+			"do X with /skill:a and /skill:b",
+			(name) => (["a", "b"].includes(name) ? ref(name) : undefined),
+			(skill) => `${skill.name} body`,
+			undefined,
+			{ includeLeading: true },
+		)!;
+		const combined = inlineSkillsIntoText(result.text, result.skills);
+
+		expect(combined).toBe(`${result.skills[0].block}\n\n${result.skills[1].block}\n\n${result.text}`);
+		expect(combined).toContain("a body");
+		expect(combined).toContain("b body");
+		expect(combined.trimEnd().endsWith(result.text)).toBe(true);
+	});
+
+	it("returns the text unchanged when there are no skills", () => {
+		expect(inlineSkillsIntoText("just text", [])).toBe("just text");
 	});
 });
 

--- a/tests/expand-inline-skills.test.ts
+++ b/tests/expand-inline-skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "bun:test";
-import { extractInlineSkillDisplays, inlineSkillsIntoText, type InlineSkillRef } from "../index";
+import { extractInlineSkillDisplays, inlineSkillsIntoText, planInlineSkillDelivery, type InlineSkillRef } from "../index";
 
 /**
  * `extractInlineSkillDisplays` lets one message reference multiple skills without
@@ -167,6 +167,39 @@ describe("inlineSkillsIntoText (steer/followUp single-entry delivery)", () => {
 
 	it("returns the text unchanged when there are no skills", () => {
 		expect(inlineSkillsIntoText("just text", [])).toBe("just text");
+	});
+});
+
+describe("planInlineSkillDelivery (the streaming-regression seam)", () => {
+	function extractTwo() {
+		return extractInlineSkillDisplays(
+			"do X with /skill:a and /skill:b",
+			(name) => (["a", "b"].includes(name) ? ref(name) : undefined),
+			(skill) => `${skill.name} body`,
+			undefined,
+			{ includeLeading: true },
+		)!;
+	}
+
+	it("streaming: sends NO separate messages and inlines every block into the text", () => {
+		const result = extractTwo();
+		const plan = planInlineSkillDelivery(result, true);
+
+		// The bug was separate skill messages splitting across one-at-a-time drains.
+		expect(plan.messages).toEqual([]);
+		expect(plan.text).toBe(inlineSkillsIntoText(result.text, result.skills));
+		expect(plan.text).toContain("a body");
+		expect(plan.text).toContain("b body");
+		expect(plan.text.trimEnd().endsWith(result.text)).toBe(true);
+	});
+
+	it("idle: keeps skills as separate messages and leaves the user text clean", () => {
+		const result = extractTwo();
+		const plan = planInlineSkillDelivery(result, false);
+
+		expect(plan.messages).toBe(result.skills);
+		expect(plan.text).toBe(result.text);
+		expect(plan.text).not.toContain("a body");
 	});
 });
 


### PR DESCRIPTION
## Summary

Skill prompts sent **while the agent is streaming** were being invoked before the message that referenced them. A steer/followUp message like `analyze this /skill:diagnosing-bugs` would fire the skill in its own isolated turn, and the user's actual instruction would arrive a turn later — so the model acted on the skill with no request attached.

Root cause is an interaction with pi core's steering queue. For multi-skill or non-leading-skill prompts, the `input` handler emitted each skill as a separate `pi.sendMessage(..., { deliverAs })` **and** returned a transformed user-text message. During streaming those become two separate entries in pi's steering queue, and `PendingMessageQueue.drain()` in the default `steeringMode: "one-at-a-time"` returns only the first entry. Result: the skill body drains alone, the instruction drains next turn.

The idle path was never affected — there the skill custom message and the user message land in the same turn.

## Fix

When streaming, deliver the skill body and the user text as a **single** queued entry by inlining the skill blocks into the transformed text, instead of sending separate messages. Idle keeps the existing behavior (separate `[skill]` rows in the same turn).

The idle-vs-streaming decision is extracted into a small pure function, `planInlineSkillDelivery`, so the branch the regression turns on is directly unit-testable.

### Edge case: leading prompt-template + inline skill

Prepending skill XML naively would move a surviving leading slash-command off position 0. Core's `expandPromptTemplate` only runs when `text.startsWith("/")` (and it replaces the whole message), so a prompt like `/tmpl arg /skill:a` would silently stop expanding the template.

`planInlineSkillDelivery` therefore inlines **only when the cleaned prompt has no leading slash-command**. If a leading `/tmpl …` survives, it falls back to separate skill messages (with `deliverAs` preserved) so core keeps expanding the template. This is precise because the streaming path already strips every `/skill:` token, so the only leading token that can survive is a genuine template. The skills may split across drains in that rare combo — same as before this change — but template expansion is preserved.

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Idle `/skill:` prompt | Skill row + prompt, same turn | unchanged |
| Streaming `... /skill:x` (no leading command) | Skill invoked alone, instruction next turn | Skill + instruction in one turn |
| Streaming `/tmpl … /skill:x` | Template expands; skill split | Template expands; skill split (unchanged) |

LLM-visible content is identical to the idle path — the same `skill.block` (including the `<skill_context>` decoration) in the same order. The only trade-off is cosmetic: in the inlined streaming case the skill body rides inside the user message instead of a collapsible `[skill]` row, because a one-at-a-time queue cannot atomically deliver a custom message plus the user message.

## Tests

Added unit coverage in `tests/expand-inline-skills.test.ts`:
- `inlineSkillsIntoText` prepends every block before the user text (and is a no-op with no skills).
- `planInlineSkillDelivery` streaming → zero separate messages + inlined text; idle → separate messages + clean text; **streaming with a leading slash-command → no inline, leading token preserved** (guards the template regression).

`bun test tests/` → **57 pass / 0 fail**.

## Review

Reviewed across GPT-5.5, GLM-5.2, and Claude Opus. The template-expansion edge case was surfaced by the GPT full-diff pass and is fixed here.
